### PR TITLE
fix: get rid of caching issue showing up in inspect console saying it…

### DIFF
--- a/client-ng/src/app/features/earnings-calendar/earnings-calendar.component.html
+++ b/client-ng/src/app/features/earnings-calendar/earnings-calendar.component.html
@@ -1,4 +1,5 @@
+<nz-card>
 @for (earning of earningsCalendar(); track $index) {
-  {{ earning.symbol }} reports on {{ earning.date }} | Estimated EPS: {{ earning.epsEstimated }}, Estimated Revenue: {{ earning.revenueEstimated }}
-  <br>
+  <h1>{{ earning.symbol }} reports on {{ earning.date }} | Estimated EPS: {{ earning.epsEstimated }}, Estimated Revenue: {{ earning.revenueEstimated }}</h1>
 }
+</nz-card>

--- a/client-ng/src/app/features/earnings-calendar/earnings-calendar.component.ts
+++ b/client-ng/src/app/features/earnings-calendar/earnings-calendar.component.ts
@@ -1,27 +1,29 @@
 import { Component, inject, OnInit, signal, WritableSignal } from '@angular/core';
 import { EarningsCalendarService } from '../../core/services/earnings-calendar.service';
 import { EarningsCalendarModel } from '../../shared/models/earnings-calendar-model';
+import { NzCardComponent } from 'ng-zorro-antd/card';
 
 @Component({
   selector: 'app-earnings-calendar',
-  imports: [],
+  imports: [
+    NzCardComponent
+  ],
   templateUrl: './earnings-calendar.component.html',
   styleUrl: './earnings-calendar.component.scss'
 })
 export class EarningsCalendarComponent implements OnInit {
-  earningsCalendarService = inject(EarningsCalendarService);
+  private earningsCalendarService = inject(EarningsCalendarService);
 
-  from: string = "2025-11-01";
-  to: string = "2025-11-30";
-
+  protected from: WritableSignal<string> = signal("2025-11-01");
+  protected to: WritableSignal<string> = signal("2025-11-30");
   protected earningsCalendar: WritableSignal<EarningsCalendarModel[] | undefined> = signal(undefined);
 
   ngOnInit() {
     this.getEarningsCalendar();
   }
 
-  getEarningsCalendar() {
-    this.earningsCalendarService.getCongressionalTrades(this.from, this.to).subscribe({
+  private getEarningsCalendar() {
+    this.earningsCalendarService.getCongressionalTrades(this.from(), this.to()).subscribe({
       next: response => this.earningsCalendar.set(response),
       error: err => console.log(err)
     });


### PR DESCRIPTION
… could not parse earnings calendar json (?) (purely browser problem, solved with hard refresh